### PR TITLE
fix: new line causes an empty gallery item

### DIFF
--- a/src/WrapImagesInGallery.php
+++ b/src/WrapImagesInGallery.php
@@ -13,7 +13,9 @@ class WrapImagesInGallery
     public function __invoke(Renderer $renderer, $context, string $xml): string
     {
         return preg_replace_callback('/'.self::MATCH_GALLERY_REGEX.'/m', function ($matches) {
-            $images = preg_split('/\s*(?:<br\/>|<br>|\n)\s*/', $matches[0]);
+            $images = array_filter(preg_split('/\s*(?:<br\/>|<br>|\n)\s*/', $matches[0]), function($img) {
+                return !empty($img);
+            });
             $galleryItems = array_map(function($img) {
                 return '<FANCYBOX-GALLERY-ITEM>' . trim($img) . '</FANCYBOX-GALLERY-ITEM>';
             }, $images);


### PR DESCRIPTION
A new line right after an image preview can create an empty gallery item. This PR's changes will filter the empty item out.

To reproduce:
```markdown
[upl-image-preview url=xxxx.png]
Breaks
```